### PR TITLE
Add audio option in quality dropdown

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -180,6 +180,11 @@
            <string>mobile_low</string>
           </property>
          </item>
+          <item>
+          <property name="text">
+           <string>audio</string>
+          </property>
+         </item>
         </widget>
        </item>
        <item row="2" column="0" colspan="2">


### PR DESCRIPTION
 I make a lot of use of the audio stream when stuck with limited bandwidth. To me, commentary is better than nothing.
